### PR TITLE
Fixed an issue that was causing a crash on the release build when assigning the bluetooth data using and if let statement

### DIFF
--- a/Bluejay/Bluejay/ReadResult.swift
+++ b/Bluejay/Bluejay/ReadResult.swift
@@ -20,18 +20,14 @@ extension ReadResult where R: Receivable {
 
     /// Create a typed read result from raw data.
     init(dataResult: ReadResult<Data?>) {
-        switch dataResult {
-        case .success(let data):
-            if let data = data {
-                do {
-                    self = .success(try R(bluetoothData: data))
-                } catch {
-                    self = .failure(error)
-                }
-            } else {
-                self = .failure(BluejayError.missingData)
-            }
-        case .failure(let error):
+        guard case .success(let data) = dataResult, let data else {
+            self = .failure(BluejayError.missingData)
+            return
+        }
+        
+        do {
+            self = .success(try R(bluetoothData: data))
+        } catch {
             self = .failure(error)
         }
     }


### PR DESCRIPTION

### Fixes #:
A **Thread 1: EXC_BAD_ACCESS** crash that was occurring on the released build of the app. 
### Summary of Problem:
For some reason, the crash was occurring 

case .success(let data):
            if let data = data {
                do {
                    self = .success(try R(bluetoothData: data))    <--- here on the .success
                } catch {
                    self = .failure(error)
                }
            }

### Proposed Solution:
After switching it to a guard let it fix the issue.

### Testing Completed and Required:


### Screenshots:
